### PR TITLE
Updated to node-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # broccoli-sass
 
-The broccoli-sass plugin compiles `.scss` files with
+The broccoli-sass plugin compiles `.scss` and `.sass` files with
 [libsass](https://github.com/hcatlin/libsass).
 
 ## Installation
@@ -20,7 +20,7 @@ var outputTree = compileSass(inputTrees, inputFile, outputFile, options);
 * **`inputTrees`**: An array of trees that act as the include paths for
   libsass. If you have a single tree, pass `[tree]`.
 
-* **`inputFile`**: Relative path of the main `.scss` file to compile. This
+* **`inputFile`**: Relative path of the main `.scss` or `.sass` file to compile. This
   file must exist in one of the `inputTrees`.
 
 * **`outputFile`**: Relative path of the output CSS file.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "include-path-searcher": "^0.1.0",
     "broccoli-writer": "^0.1.1",
     "rsvp": "^3.0.6",
-    "node-sass": "^0.8.5"
+    "node-sass": "~0.9.2"
   }
 }


### PR DESCRIPTION
Gives us the ability to use both the `scss` and `sass` syntax.
