### PR TITLE
Pass the precision option to the sass compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ function SassCompiler (sourceTrees, inputFile, outputFile, options) {
     imagePath: options.imagePath,
     outputStyle: options.outputStyle,
     sourceComments: options.sourceComments,
-    sourceMap: options.sourceMap
+    sourceMap: options.sourceMap,
+    precision: options.precision
   }
 }
 


### PR DESCRIPTION
Enabled changing the decimal precision. Default to the original value of 5 to not break anything.

Fixes #23
![selfie-0](http://i.imgur.com/atRt5K5.gif)
