### PR TITLE
Use broccoli-caching-writer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "libsass"
   ],
   "dependencies": {
-    "mkdirp": "^0.3.5",
-    "lodash": "~2.4.1",
-    "promise-map-series": "^0.2.0",
+    "broccoli-caching-writer": "^0.5.0",
     "include-path-searcher": "^0.1.0",
-    "broccoli-writer": "^0.1.1",
-    "rsvp": "^3.0.6",
-    "node-sass": "~0.9.3"
+    "lodash": "~2.4.1",
+    "mkdirp": "^0.3.5",
+    "node-sass": "~0.9.3",
+    "rsvp": "^3.0.6"
   }
 }


### PR DESCRIPTION
Even though libsass is insanely fast, we still see broccoli-sass in the "slow-trees listing" (at around 250ms) for every rebuild regardless of what files were changed.

This change updates to inherit from broccoli-caching-writer, which simply symlinks (using symlink-or-copy package) from the last runs cache directory if the input trees have not changed.

The result of this is that when changing files in a tree other than those provided to broccoli-sass the broccoli-sass tree rebuilds are nearly instant ( less than 10ms on SSD ).

In the future, we can even restrict extraneous rebuilds further by using broccoli-caching-writer's new include/exclude patterns to prevent cache invalidation when files inside the inputTrees but not related to the sass compilation are changed.

Closes #26.
