### PR TITLE
use path.join for destFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ SassCompiler.prototype.updateCache = function(includePaths, destDir) {
   var self = this
 
   return new Promise(function(resolve, reject) {
-    var destFile = destDir + self.outputFile
+    var destFile = path.join(destDir, self.outputFile);
     mkdirp.sync(path.dirname(destFile))
 
     var sassOptions = {


### PR DESCRIPTION
The destFile ended up being something like `tmp/sass_compiler-tmp_cache_dir-ILqw5MKk.tmpapp.css` instead of `tmp/sass_compiler-tmp_cache_dir-ILqw5MKk.tmp/app.css`. Using `path.join` should fix this, or am I missing something? 

I make a quick demo repo to outline the issue https://github.com/moudy/broccoli-sass-output-file-test/blob/master/Brocfile.js
