### PR TITLE
Use path.join to fix regression bug re. missing leading slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ SassCompiler.prototype.updateCache = function(includePaths, destDir) {
   var self = this
 
   return new Promise(function(resolve, reject) {
-    var destFile = destDir + self.outputFile
+    var destFile = path.join(destDir, self.outputFile)
     mkdirp.sync(path.dirname(destFile))
 
     var sassOptions = {


### PR DESCRIPTION
https://github.com/joliss/broccoli-sass/pull/28 introduced a regression bug that made output paths without leading slashes not work. No leading slash is the documented behavior in the README.

https://github.com/joliss/broccoli-sass/commit/10df2aa70871065ac0d6b0d500b7457ae9b53cf4#diff-168726dbe96b3ce427e7fedce31bb0bcL34
was changed to
https://github.com/joliss/broccoli-sass/commit/10df2aa70871065ac0d6b0d500b7457ae9b53cf4#diff-168726dbe96b3ce427e7fedce31bb0bcR35

I fixed it using `path.join`, which I think should always be used, except when called repeatedly for performance optimization.

I recommend releasing a new version asap as this will break the build for everyone who are not using leading slashes.
