### PR TITLE
Update for Libsass 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-sass",
   "description": "Libsass-based Sass compiler for Broccoli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "author": "Jo Liss <joliss42@gmail.com>",
   "main": "index.js",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "include-path-searcher": "^0.1.0",
     "lodash": "~2.4.1",
     "mkdirp": "^0.3.5",
-    "node-sass": "~0.9.3",
+    "node-sass": "~1.0",
     "rsvp": "^3.0.6"
   }
 }


### PR DESCRIPTION
Hi,

I'm not sure if those are the only needed changes, but it sets dependency to node-sass 1, which depends on libsass 3 (that has support for extend \o/ !)
