### PR TITLE
Upgraded to node-sass 1.03 to fix other OS build installation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "include-path-searcher": "^0.1.0",
     "lodash": "~2.4.1",
     "mkdirp": "^0.3.5",
-    "node-sass": "^1.0.1",
+    "node-sass": "^1.0.3",
     "rsvp": "^3.0.6"
   }
 }


### PR DESCRIPTION
The bug in node-sass: https://github.com/sass/node-sass/issues/467 makes it crash when installing in Unix and Windows (including lots of hosting servers like Heroku)
