### PR TITLE
Update node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "broccoli-caching-writer": "^0.5.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.0.0-pre"
+    "node-sass": "^3.0.0-alpha.0"
   }
 }


### PR DESCRIPTION
Is (almost) the same as 3.0.0-pre, but comes with prebuilt binaries, which speedup the package installation.