### PR TITLE
Update package.json with latest node-sass with windows fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "broccoli-caching-writer": "^0.5.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.0.0-alpha"
+    "node-sass": "^3.0.0-alpha.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "broccoli-caching-writer": "^0.5.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.0.0-pre"
+    "node-sass": "^3.0.0-alpha"
   }
 }


### PR DESCRIPTION
Using alpha instead of pre version of node-sass to have this plugin work on windows.  #54 is predated compared to this one.