### PR TITLE
Bump node sass to v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "broccoli-caching-writer": "^2.0.4",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.3.3"
+    "node-sass": "^3.4.1"
   },
   "devDependencies": {
     "broccoli-fixture": "^0.1.0",


### PR DESCRIPTION
From https://github.com/sass/node-sass/releases/tag/v3.4.0

This release has the latest LibSass 3.3.0 release which brings with it
major feature parity Ruby Sass*, massive speed improvements and MUCH
MORE!

I also saw a speed improvement.
