### PR TITLE
Update node sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "broccoli-caching-writer": "^2.0.4",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.4.1"
+    "node-sass": "4.5.3"
   },
   "devDependencies": {
     "broccoli-fixture": "^0.1.0",


### PR DESCRIPTION
With node-sass on 3.x npm install fails on docker's node:4-apline image while trying to run node-sass's post-installation script. Updating to 4.x fixes this.